### PR TITLE
Ensure "All" filter is active before proceeding

### DIFF
--- a/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
+++ b/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
@@ -23,10 +23,14 @@ for (LeaguePanelFilterType filterType : LeaguePanelFilterType.values()) {
     }
 
     private boolean isOptionSelected(SimpleWidget widget) {
-        if (widget == null || widget.getChild(4) == null || widget.getChild(4).getText() == null) {
+        if (widget == null) {
             return false;
         }
-        return widget.getChild(4).getText().equalsIgnoreCase("all");
+        final SimpleWidget child = widget.getChild(4);
+        if (child == null) {
+            return false;
+        }
+        return "all".equalsIgnoreCase(child.getText());
     }
 
     private boolean chooseAllInDropDown(int filterWidgetId, int filterDropdownOptionId) {

--- a/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
+++ b/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
@@ -1,0 +1,123 @@
+package me.remie.vulcan.leaguetasks.utils;
+
+import simple.hooks.simplebot.Game;
+import simple.hooks.wrappers.SimpleWidget;
+import simple.robot.api.ClientContext;
+
+public class LeaguePanel {
+    private ClientContext ctx;
+    private static final int WIDGET_ID = 657;
+
+    public LeaguePanel(final ClientContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public boolean doWeNeedToClearFilters() {
+        final SimpleWidget tierDropDownMenu = ctx.widgets.getWidget(WIDGET_ID, LeaguePanelFilterType.FILTER_TIER.getWidgetId());
+        if (!isOptionSelected(tierDropDownMenu)) {
+            return true;
+        }
+
+        final SimpleWidget typeDropDownMenu = ctx.widgets.getWidget(WIDGET_ID, LeaguePanelFilterType.FILTER_TYPE.getWidgetId());
+        if (!isOptionSelected(typeDropDownMenu)) {
+            return true;
+        }
+
+        final SimpleWidget areaDropDownMenu = ctx.widgets.getWidget(WIDGET_ID,LeaguePanelFilterType.FILTER_AREA.getWidgetId());
+        if (!isOptionSelected(areaDropDownMenu)) {
+            return true;
+        }
+
+        final SimpleWidget completedDropDownMenu = ctx.widgets.getWidget(WIDGET_ID, LeaguePanelFilterType.FILTER_COMPLETED.getWidgetId());
+        if (!isOptionSelected(completedDropDownMenu)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isOptionSelected(SimpleWidget widget) {
+        if (widget == null || widget.getChild(4) == null || widget.getChild(4).getText() == null) {
+            return false;
+        }
+        return widget.getChild(4).getText().equalsIgnoreCase("all");
+    }
+
+    private boolean chooseAllInDropDown(int filterWidgetId, int filterDropdownOptionId) {
+        final SimpleWidget filterDropDownMenu = ctx.widgets.getWidget(WIDGET_ID,filterWidgetId);
+        if (filterDropDownMenu != null) {
+            if (!isOptionSelected(filterDropDownMenu)) {
+                final SimpleWidget selectedOption = filterDropDownMenu.getChild(4);
+                final SimpleWidget dropDownMenu = ctx.widgets.getWidget(WIDGET_ID, filterDropdownOptionId);
+                if (!chooseOptionInDropdown(selectedOption, dropDownMenu)) {
+                    ctx.log("Something went wrong choosing all in options");
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public boolean clearAllFilterOptions() {
+        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_TIER.getWidgetId(), LeaguePanelFilterType.FILTER_TIER.getAllOptionWidgetId())) {
+            ctx.log("Something went wrong choosing tier option");
+            return false;
+        }
+
+        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_TYPE.getWidgetId(), LeaguePanelFilterType.FILTER_TYPE.getAllOptionWidgetId())) {
+            ctx.log("Something went wrong choosing type option");
+            return false;
+        }
+
+        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_AREA.getWidgetId(), LeaguePanelFilterType.FILTER_AREA.getAllOptionWidgetId())) {
+            ctx.log("Something went wrong choosing area option");
+            return false;
+        }
+
+        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_COMPLETED.getWidgetId(), LeaguePanelFilterType.FILTER_COMPLETED.getAllOptionWidgetId())) {
+            ctx.log("Something went wrong choosing completed option");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean chooseOptionInDropdown(SimpleWidget dropDownWidget, SimpleWidget dropDownOptionList) {
+        if (dropDownWidget == null || dropDownWidget.getChild(1) == null) {
+            return false;
+        }
+
+        dropDownWidget.click(1);
+        ctx.sleep(1500);
+        if (dropDownOptionList != null && !dropDownOptionList.isHidden()) {
+            final SimpleWidget selectedOption = dropDownOptionList.getChild(1);
+            if (selectedOption != null) {
+                selectedOption.click(1);
+                ctx.sleep(1300);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isLeaguePanelOpen() {
+        final SimpleWidget leaguePanelWidget = getLeaguePanelWidget();
+        return leaguePanelWidget != null && !leaguePanelWidget.isHidden();
+    }
+
+    public boolean openLeaguePanel() {
+        if (isLeaguePanelOpen()) {
+            return true;
+        }
+
+        ctx.log("Opening leagues menu");
+        ctx.game.tab(Game.Tab.QUESTS);
+        ctx.menuActions.clickButton(41222167);
+        ctx.sleep(1000);
+        ctx.menuActions.clickButton(42991640);
+        return ctx.onCondition(() -> isLeaguePanelOpen(), 1000, 5);
+    }
+
+    public SimpleWidget getLeaguePanelWidget() {
+        return ctx.widgets.getWidget(WIDGET_ID,18);
+    }
+}

--- a/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
+++ b/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
@@ -5,7 +5,7 @@ import simple.hooks.wrappers.SimpleWidget;
 import simple.robot.api.ClientContext;
 
 public class LeaguePanel {
-    private ClientContext ctx;
+    private final ClientContext ctx;
     private static final int WIDGET_ID = 657;
 
     public LeaguePanel(final ClientContext ctx) {

--- a/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
+++ b/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
@@ -13,26 +13,12 @@ public class LeaguePanel {
     }
 
     public boolean doWeNeedToClearFilters() {
-        final SimpleWidget tierDropDownMenu = ctx.widgets.getWidget(WIDGET_ID, LeaguePanelFilterType.FILTER_TIER.getWidgetId());
-        if (!isOptionSelected(tierDropDownMenu)) {
-            return true;
+for (LeaguePanelFilterType filterType : LeaguePanelFilterType.values()) {
+            SimpleWidget dropDownMenu = ctx.widgets.getWidget(WIDGET_ID, filterType.getWidgetId());
+            if (!isOptionSelected(dropDownMenu)) {
+                return true;
+            }
         }
-
-        final SimpleWidget typeDropDownMenu = ctx.widgets.getWidget(WIDGET_ID, LeaguePanelFilterType.FILTER_TYPE.getWidgetId());
-        if (!isOptionSelected(typeDropDownMenu)) {
-            return true;
-        }
-
-        final SimpleWidget areaDropDownMenu = ctx.widgets.getWidget(WIDGET_ID,LeaguePanelFilterType.FILTER_AREA.getWidgetId());
-        if (!isOptionSelected(areaDropDownMenu)) {
-            return true;
-        }
-
-        final SimpleWidget completedDropDownMenu = ctx.widgets.getWidget(WIDGET_ID, LeaguePanelFilterType.FILTER_COMPLETED.getWidgetId());
-        if (!isOptionSelected(completedDropDownMenu)) {
-            return true;
-        }
-
         return false;
     }
 

--- a/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
+++ b/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
@@ -34,16 +34,15 @@ for (LeaguePanelFilterType filterType : LeaguePanelFilterType.values()) {
     }
 
     private boolean chooseAllInDropDown(int filterWidgetId, int filterDropdownOptionId) {
-        final SimpleWidget filterDropDownMenu = ctx.widgets.getWidget(WIDGET_ID,filterWidgetId);
-        if (filterDropDownMenu != null) {
-            if (!isOptionSelected(filterDropDownMenu)) {
-                final SimpleWidget selectedOption = filterDropDownMenu.getChild(4);
-                final SimpleWidget dropDownMenu = ctx.widgets.getWidget(WIDGET_ID, filterDropdownOptionId);
-                if (!chooseOptionInDropdown(selectedOption, dropDownMenu)) {
-                    ctx.log("Something went wrong choosing all in options");
-                    return false;
-                }
-            }
+        final SimpleWidget filterDropDownMenu = ctx.widgets.getWidget(WIDGET_ID, filterWidgetId);
+        if (filterDropDownMenu == null || isOptionSelected(filterDropDownMenu)) {
+            return true;
+        }
+        final SimpleWidget selectedOption = filterDropDownMenu.getChild(4);
+        final SimpleWidget dropDownMenu = ctx.widgets.getWidget(WIDGET_ID, filterDropdownOptionId);
+        if (!chooseOptionInDropdown(selectedOption, dropDownMenu)) {
+            ctx.log("Something went wrong choosing all in options");
+            return false;
         }
         return true;
     }

--- a/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
+++ b/src/me/remie/vulcan/leaguetasks/utils/LeaguePanel.java
@@ -45,24 +45,11 @@ for (LeaguePanelFilterType filterType : LeaguePanelFilterType.values()) {
     }
 
     public boolean clearAllFilterOptions() {
-        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_TIER.getWidgetId(), LeaguePanelFilterType.FILTER_TIER.getAllOptionWidgetId())) {
-            ctx.log("Something went wrong choosing tier option");
-            return false;
-        }
-
-        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_TYPE.getWidgetId(), LeaguePanelFilterType.FILTER_TYPE.getAllOptionWidgetId())) {
-            ctx.log("Something went wrong choosing type option");
-            return false;
-        }
-
-        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_AREA.getWidgetId(), LeaguePanelFilterType.FILTER_AREA.getAllOptionWidgetId())) {
-            ctx.log("Something went wrong choosing area option");
-            return false;
-        }
-
-        if (!chooseAllInDropDown(LeaguePanelFilterType.FILTER_COMPLETED.getWidgetId(), LeaguePanelFilterType.FILTER_COMPLETED.getAllOptionWidgetId())) {
-            ctx.log("Something went wrong choosing completed option");
-            return false;
+        for (LeaguePanelFilterType filterType : LeaguePanelFilterType.values()) {
+            if (!chooseAllInDropDown(filterType.getWidgetId(), filterType.getAllOptionWidgetId())) {
+                ctx.log("Something went wrong choosing " + filterType.name() + " option");
+                return false;
+            }
         }
         return true;
     }

--- a/src/me/remie/vulcan/leaguetasks/utils/LeaguePanelFilterType.java
+++ b/src/me/remie/vulcan/leaguetasks/utils/LeaguePanelFilterType.java
@@ -1,0 +1,24 @@
+package me.remie.vulcan.leaguetasks.utils;
+
+public enum LeaguePanelFilterType {
+    FILTER_TIER(27, 35),
+    FILTER_TYPE(28, 36),
+    FILTER_AREA(29, 37),
+    FILTER_COMPLETED(31, 39);
+
+    private final int widgetId;
+    private final int allOptionWidgetId;
+
+    LeaguePanelFilterType( int widgetId, int allOptionWidgetId) {
+        this.widgetId = widgetId;
+        this.allOptionWidgetId = allOptionWidgetId;
+    }
+
+    public int getWidgetId() {
+        return widgetId;
+    }
+
+    public int getAllOptionWidgetId() {
+        return allOptionWidgetId;
+    }
+}


### PR DESCRIPTION
This commit introduces a check to ensure that the 'All' filter is active within the dropdown menu widget before proceeding with any further actions.

Previously, the filter state was not verified,
possibly leading to incorrect behavior if the filter was set to something other than 'All'.